### PR TITLE
make Cut implicitly inherit an "object"

### DIFF
--- a/scalpl/scalpl.py
+++ b/scalpl/scalpl.py
@@ -83,7 +83,7 @@ def traverse(data: dict, keys: List[Union[str, int]], original_path: str):
     return value
 
 
-class Cut:
+class Cut(object):
     """
     Cut is a simple wrapper over the built-in dict class.
 


### PR DESCRIPTION
we should have the base class in the `class Cut(object)` - even if Python implicitly does that already.

```
class Foo:
    pass


class Bar(Foo):
    pass
``` 
vs:
```
class Foo(object):
    pass


class Bar(Foo):
    pass
```
    
seems to be much cleaner.